### PR TITLE
fix: use Sprintf instead of prepared statement at building query

### DIFF
--- a/backend/app/resolver/page.go
+++ b/backend/app/resolver/page.go
@@ -50,9 +50,9 @@ func pageDB(db *gorm.DB, col string, dir direction, page model.PaginationInput) 
 		} else {
 			switch dir {
 			case asc:
-				db = db.Where("? > ?", col, resource1.ID)
+				db = db.Where(fmt.Sprintf("%s > ?", col), resource1.ID)
 			case desc:
-				db = db.Where("? < ?", col, resource1.ID)
+				db = db.Where(fmt.Sprintf("%s < ?", col), resource1.ID)
 			}
 		}
 	}


### PR DESCRIPTION
# WHAT
 - sqlを組み立てる部分で、カラムに prepared statementを使っていたことで発行されるsqlが以下のようになっていた
   - `SELECT * FROM `tasks`  WHERE `tasks`.`deleted_at` IS NULL AND (('id' < 11)) ORDER BY id DESC, id DESC LIMIT 11  `
   - これではうまく取ってこれない(idがシングルクォーテーションで囲まれている)

- カラムの部分はSprintfで組み立てる、col自体はサーバー側で決まった値を使ってるのでsqlインジェクションとかも問題なさそう